### PR TITLE
Messenger Bundle eingebaut

### DIFF
--- a/app/src/main/java/li/klass/fhem/service/intent/ExternalApiService.java
+++ b/app/src/main/java/li/klass/fhem/service/intent/ExternalApiService.java
@@ -62,12 +62,12 @@ public class ExternalApiService extends Service {
         }
     }
 
-    private void replyTo(Message incoming, String outgoing) {
+    private void replyTo(Message incoming, ArrayList<String> outgoing) {
         try {
             if (incoming.replyTo != null) {
                 Message msg = Message.obtain(null, 1);
                 Bundle bundle = new Bundle();
-                bundle.putString("data", outgoing);
+                bundle.putStringArrayList("data", outgoing);
                 msg.setData(bundle);
                 incoming.replyTo.send(msg);
             }


### PR DESCRIPTION
ungetestet, aber so sollte sich der derzeitige Crash verhindern lassen. Siehe auch http://stackoverflow.com/questions/6596291/send-object-from-service-to-activity-cant-marshal-non-parcelable
