### PR TITLE
Add initial support for plotReplace and fixedrange

### DIFF
--- a/app/src/main/java/li/klass/fhem/graph/backend/GraphDefinitionsForDeviceService.kt
+++ b/app/src/main/java/li/klass/fhem/graph/backend/GraphDefinitionsForDeviceService.kt
@@ -83,57 +83,6 @@ class GraphDefinitionsForDeviceService @Inject constructor(
         return SvgGraphDefinition(currentDevice.name, gPlotDefinition, logDeviceName, labels, title, fixedrange, plotReplace, plotfunction)
     }
 
-    private fun fixedrangeFor(device : XmlListDevice): Pair<ReadablePeriod, ReadablePeriod>? {
-        val attr = (device.getAttribute("fixedrange") ?: "").trim().split(" ")
-        val range = attr[0]
-        val offset = if (attr.size > 1 ) { parseInt(attr[1]) } else { 0 }
-        val m = Pattern.compile("([0-9]*)(hour|day|week|month|year)s?").matcher(range)
-        return if (m.matches()) {
-            val count = when {
-                m.group(1).isEmpty() -> 1
-                else -> parseInt(m.group(1))
-            }
-            when (m.group(2)) {
-                "hour" -> Pair(Hours.hours(count), Hours.hours(count * offset))
-                "day" -> Pair(Days.days(count), Days.days(count * offset))
-                "week" -> Pair(Weeks.weeks(count), Weeks.weeks(count * offset))
-                "month" -> Pair(Months.months(count), Months.months(count * offset))
-                "year" -> Pair(Years.years(count), Years.years(count * offset))
-                else -> null
-            }
-        } else {
-            null
-        }
-    }
-
-    private fun plotReplaceMapFor(device: XmlListDevice): Map<String, String> {
-        val attr = (device.getAttribute("plotReplace") ?: "").trim()
-        val plotReplace = HashMap<String, String>()
-        // Split into single variable definitions respecting quotes and curly braces
-        var text = ""
-        var quoted = false;
-        var braceDepth = 0;
-        attr.forEach {
-            if (it.isWhitespace() && !quoted && braceDepth == 0) {
-                val char = text.indexOf('=')
-                plotReplace[text.substring(0, char).trim()] = text.substring(char + 1)
-            } else if (it == '"' && braceDepth == 0) {
-                quoted = !quoted
-            } else if (it == '{') {
-                braceDepth += 1
-            } else if (it == '}') {
-                braceDepth -= 1
-            } else {
-                text += it
-            }
-        }
-        if (text.isNotEmpty()) {
-            val char = text.indexOf('=')
-            plotReplace[text.substring(0, char).trim()] = text.substring(char + 1)
-        }
-        return plotReplace
-    }
-
     private fun plotfunctionListFor(device: XmlListDevice): List<String> {
         return (device.getAttribute("plotfunction") ?: "").trim()
                 .split(" ".toRegex())
@@ -175,5 +124,57 @@ class GraphDefinitionsForDeviceService @Inject constructor(
 
     companion object {
         private val LOGGER = LoggerFactory.getLogger(GraphDefinitionsForDeviceService::class.java)
+
+        fun fixedrangeFor(device : XmlListDevice): Pair<ReadablePeriod, ReadablePeriod>? {
+            val attr = (device.getAttribute("fixedrange") ?: "").trim().split(" ")
+            val range = attr[0]
+            val offset = if (attr.size > 1 ) { parseInt(attr[1]) } else { 0 }
+            val m = Pattern.compile("([0-9]*)(hour|day|week|month|year)s?").matcher(range)
+            return if (m.matches()) {
+                val count = when {
+                    m.group(1).isEmpty() -> 1
+                    else -> parseInt(m.group(1))
+                }
+                when (m.group(2)) {
+                    "hour" -> Pair(Hours.hours(count), Hours.hours(count * offset))
+                    "day" -> Pair(Days.days(count), Days.days(count * offset))
+                    "week" -> Pair(Weeks.weeks(count), Weeks.weeks(count * offset))
+                    "month" -> Pair(Months.months(count), Months.months(count * offset))
+                    "year" -> Pair(Years.years(count), Years.years(count * offset))
+                    else -> null
+                }
+            } else {
+                null
+            }
+        }
+
+        fun plotReplaceMapFor(device: XmlListDevice): Map<String, String> {
+            val attr = (device.getAttribute("plotReplace") ?: "").trim()
+            val plotReplace = HashMap<String, String>()
+            // Split into single variable definitions respecting quotes and curly braces
+            var text = ""
+            var quoted = false;
+            var braceDepth = 0;
+            attr.forEach {
+                if (it.isWhitespace() && !quoted && braceDepth == 0) {
+                    val char = text.indexOf('=')
+                    plotReplace[text.substring(0, char).trim()] = text.substring(char + 1)
+                    text = ""
+                } else if (it == '"' && braceDepth == 0) {
+                    quoted = !quoted
+                } else if (it == '{' && !quoted) {
+                    braceDepth += 1
+                } else if (it == '}' && !quoted) {
+                    braceDepth -= 1
+                } else {
+                    text += it
+                }
+            }
+            if (text.isNotEmpty()) {
+                val char = text.indexOf('=')
+                plotReplace[text.substring(0, char).trim()] = text.substring(char + 1)
+            }
+            return plotReplace
+        }
     }
 }

--- a/app/src/main/java/li/klass/fhem/graph/backend/GraphIntervalProvider.kt
+++ b/app/src/main/java/li/klass/fhem/graph/backend/GraphIntervalProvider.kt
@@ -31,24 +31,29 @@ import li.klass.fhem.update.backend.command.execution.CommandExecutionService
 import li.klass.fhem.util.DateFormatUtil
 import org.joda.time.DateTime
 import org.joda.time.Interval
+import org.joda.time.ReadablePeriod
 import javax.inject.Inject
 
 class GraphIntervalProvider @Inject constructor(
         private val commandExecutionService: CommandExecutionService
 ) {
 
-    fun getIntervalFor(startDate: DateTime?, endDate: DateTime?, context: Context): Interval =
+    fun getIntervalFor(startDate: DateTime?, endDate: DateTime?, fixedrange : Pair<ReadablePeriod, ReadablePeriod>?, context: Context): Interval =
             if (startDate == null || endDate == null) {
-                getDefaultInterval(context)
+                getDefaultInterval(context, fixedrange)
             } else Interval(startDate, endDate)
 
-    private fun getDefaultInterval(context: Context): Interval {
+    private fun getDefaultInterval(context: Context, fixedrange : Pair<ReadablePeriod, ReadablePeriod>?): Interval {
         val result = commandExecutionService.executeSync(Command("{{ TimeNow() }}"))
-                ?: return getIntervalForTimespan(context, DateTime.now())
-        return getIntervalForTimespan(context, DateFormatUtil.FHEM_DATE_FORMAT.parseDateTime(result))
+                ?: return getIntervalForTimespan(context, fixedrange, DateTime.now())
+        return getIntervalForTimespan(context, fixedrange, DateFormatUtil.FHEM_DATE_FORMAT.parseDateTime(result))
     }
 
-    private fun getIntervalForTimespan(context: Context, endDate: DateTime): Interval {
+    private fun getIntervalForTimespan(context: Context, fixedrange : Pair<ReadablePeriod, ReadablePeriod>?, endDate: DateTime): Interval {
+        fixedrange?.let {
+            return Interval(endDate.minus(fixedrange.first).minus(fixedrange.second), endDate.minus(fixedrange.second))
+        }
+        // App settings apply only if not overridden by server
         val hoursToSubtract = getChartingDefaultTimespan(context)
         if (hoursToSubtract == CURRENT_DAY_TIMESPAN) {
             return Interval(endDate.withHourOfDay(0).withMinuteOfHour(0), endDate)

--- a/app/src/main/java/li/klass/fhem/graph/backend/GraphIntervalProvider.kt
+++ b/app/src/main/java/li/klass/fhem/graph/backend/GraphIntervalProvider.kt
@@ -51,7 +51,7 @@ class GraphIntervalProvider @Inject constructor(
 
     private fun getIntervalForTimespan(context: Context, fixedrange : Pair<ReadablePeriod, ReadablePeriod>?, endDate: DateTime): Interval {
         fixedrange?.let {
-            return Interval(endDate.minus(fixedrange.first).minus(fixedrange.second), endDate.minus(fixedrange.second))
+            return Interval(endDate.minus(fixedrange.first).plus(fixedrange.second), endDate.plus(fixedrange.second))
         }
         // App settings apply only if not overridden by server
         val hoursToSubtract = getChartingDefaultTimespan(context)
@@ -61,7 +61,7 @@ class GraphIntervalProvider @Inject constructor(
         return Interval(endDate.minusHours(hoursToSubtract), endDate)
     }
 
-    private fun getChartingDefaultTimespan(context: Context): Int {
+    fun getChartingDefaultTimespan(context: Context): Int {
         val timeSpan = PreferenceManager.getDefaultSharedPreferences(context).getString("GRAPH_DEFAULT_TIMESPAN", "24")
         return Integer.valueOf(timeSpan!!.trim { it <= ' ' })
     }

--- a/app/src/main/java/li/klass/fhem/graph/backend/GraphService.kt
+++ b/app/src/main/java/li/klass/fhem/graph/backend/GraphService.kt
@@ -153,7 +153,7 @@ class GraphService @Inject constructor(
         val parts = entry.split(" ".toRegex()).dropLastWhile { it.isEmpty() }
         if (parts.size != 2) return null
 
-        val entryTime = parts[0]
+        val entryTime = parts[0] + DEFAULT_ENTRY_DATE.substring(parts[0].length)
         val entryValue = parts[1]
         LOG.trace("Entry {}", entry);
         try {
@@ -176,6 +176,7 @@ class GraphService @Inject constructor(
 
     companion object {
         private const val ENTRY_FORMAT = "yyyy-MM-dd_HH:mm:ss"
+        private const val DEFAULT_ENTRY_DATE = "1970-01-01_00:00:00"
         private val GRAPH_ENTRY_DATE_FORMATTER = DateTimeFormat.forPattern(ENTRY_FORMAT)
         internal val DATE_TIME_FORMATTER = DateTimeFormat.forPattern("yyyy-MM-dd_HH:mm")
         internal const val COMMAND_TEMPLATE = "get %s - - %s %s %s"

--- a/app/src/main/java/li/klass/fhem/graph/backend/GraphService.kt
+++ b/app/src/main/java/li/klass/fhem/graph/backend/GraphService.kt
@@ -62,7 +62,7 @@ class GraphService @Inject constructor(
      */
     fun getGraphData(device: FhemDevice, connectionId: String?, svgGraphDefinition: SvgGraphDefinition,
                      startDate: DateTime?, endDate: DateTime?, context: Context): GraphData {
-        val interval = graphIntervalProvider.getIntervalFor(startDate, endDate, context)
+        val interval = graphIntervalProvider.getIntervalFor(startDate, endDate, svgGraphDefinition.fixedrange, context)
 
         val series: Set<GPlotSeries> = svgGraphDefinition.plotDefinition.let {
             it.leftAxis.series + it.rightAxis.series

--- a/app/src/main/java/li/klass/fhem/graph/backend/gplot/SvgGraphDefinition.kt
+++ b/app/src/main/java/li/klass/fhem/graph/backend/gplot/SvgGraphDefinition.kt
@@ -31,4 +31,5 @@ data class SvgGraphDefinition(val name: String,
                               val logDeviceName: String,
                               val labels: List<String>,
                               val title: String,
+                              val plotReplace: Map<String, String>,
                               val plotfunction: List<String>) : Serializable

--- a/app/src/main/java/li/klass/fhem/graph/backend/gplot/SvgGraphDefinition.kt
+++ b/app/src/main/java/li/klass/fhem/graph/backend/gplot/SvgGraphDefinition.kt
@@ -24,6 +24,7 @@
 
 package li.klass.fhem.graph.backend.gplot
 
+import org.joda.time.ReadablePeriod
 import java.io.Serializable
 
 data class SvgGraphDefinition(val name: String,
@@ -31,5 +32,6 @@ data class SvgGraphDefinition(val name: String,
                               val logDeviceName: String,
                               val labels: List<String>,
                               val title: String,
+                              val fixedrange: Pair<ReadablePeriod, ReadablePeriod>?,
                               val plotReplace: Map<String, String>,
                               val plotfunction: List<String>) : Serializable

--- a/app/src/test/java/li/klass/fhem/graph/backend/GraphDefinitionsForDeviceServiceTest.kt
+++ b/app/src/test/java/li/klass/fhem/graph/backend/GraphDefinitionsForDeviceServiceTest.kt
@@ -1,0 +1,49 @@
+package li.klass.fhem.graph.backend;
+
+import li.klass.fhem.domain.core.FhemDevice
+import li.klass.fhem.update.backend.xmllist.DeviceNode
+import li.klass.fhem.update.backend.xmllist.XmlListDevice
+import org.assertj.core.api.Assertions.assertThat
+import org.joda.time.*
+import org.junit.Test;
+import java.util.*
+import kotlin.collections.HashMap
+
+public class GraphDefinitionsForDeviceServiceTest {
+
+    private fun getDeviceFor(type: String, property: String, value: String?) = XmlListDevice(type).apply {
+        value?.let {
+            attributes[property] = DeviceNode(DeviceNode.DeviceNodeType.ATTR, property, value, null as DateTime?)
+        }
+    }
+
+    @Test
+    fun fixedrangeFor() {
+        val testdata = mapOf(
+                "5hours" to Pair(Hours.hours(5), Hours.hours(0)),
+                "day -2" to Pair(Days.days(1), Days.days(-2)),
+                "week" to Pair(Weeks.weeks(1), Weeks.weeks(0)),
+                "12months -10" to Pair(Months.months(12), Months.months(-120)),
+                "2years -1" to Pair(Years.years(2), Years.years(-2)),
+                "" to null,
+                null to null
+        )
+        for ((input, output) in testdata) {
+            assertThat(GraphDefinitionsForDeviceService.fixedrangeFor(getDeviceFor("SVG", "fixedrange", input))).isEqualTo(output)
+        }
+    }
+
+    @Test
+    fun plotReplaceMapFor() {
+        val testdata = mapOf(
+                "" to emptyMap<String, String>(),
+                null to emptyMap<String, String>(),
+                "INTERVAL=month" to mapOf("INTERVAL" to "month"),
+                """A="test 2 3" B={"to do" } C="x {y} z" """ to mapOf("A" to "test 2 3", "B" to """"to do" """, "C" to "x {y} z"),
+                """"X=Y + 3"""" to mapOf("X" to "Y + 3")
+        )
+        for ((input, output) in testdata) {
+            assertThat(GraphDefinitionsForDeviceService.plotReplaceMapFor(getDeviceFor("SVG", "plotReplace", input))).isEqualTo(output)
+        }
+    }
+}

--- a/app/src/test/java/li/klass/fhem/graph/backend/GraphIntervalProviderTest.kt
+++ b/app/src/test/java/li/klass/fhem/graph/backend/GraphIntervalProviderTest.kt
@@ -1,0 +1,74 @@
+package li.klass.fhem.graph.backend
+
+import android.content.Context
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.spy
+import com.nhaarman.mockito_kotlin.whenever
+import li.klass.fhem.update.backend.command.execution.Command
+import li.klass.fhem.update.backend.command.execution.CommandExecutionService
+import li.klass.fhem.util.DateFormatUtil
+import org.assertj.core.api.Assertions.assertThat
+import org.joda.time.DateTime
+import org.joda.time.Hours
+import org.joda.time.Interval
+import org.junit.Before
+import org.junit.Test
+import org.mockito.BDDMockito.given
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.MockitoAnnotations
+import org.mockito.Spy
+
+class GraphIntervalProviderTest {
+    @Mock
+    private lateinit var commandExecutionService: CommandExecutionService
+
+    @Mock
+    private lateinit var context: Context
+
+    private lateinit var graphIntervalProvider: GraphIntervalProvider
+
+    private fun <T> any(): T {
+        Mockito.any<T>()
+        return uninitialized()
+    }
+
+    private fun <T> uninitialized(): T = null as T
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.initMocks(this)
+        given(commandExecutionService.executeSync(Command("{{ TimeNow() }}"))).willReturn("2020-03-10 20:57:40")
+        graphIntervalProvider = spy(GraphIntervalProvider(commandExecutionService))
+        doReturn(24).whenever(graphIntervalProvider).getChartingDefaultTimespan(any())
+    }
+
+    @Test
+    fun getIntervalFromStartEnd() {
+        assertThat(graphIntervalProvider.getIntervalFor(
+                DateFormatUtil.FHEM_DATE_FORMAT.parseDateTime("2020-03-09 10:58:41"),
+                DateFormatUtil.FHEM_DATE_FORMAT.parseDateTime("2020-03-10 20:57:40"),
+                null,
+                context)
+        ).isEqualTo(
+                Interval(
+                        DateFormatUtil.FHEM_DATE_FORMAT.parseDateTime("2020-03-09 10:58:41"),
+                        DateFormatUtil.FHEM_DATE_FORMAT.parseDateTime("2020-03-10 20:57:40")
+                )
+        )
+    }
+
+    @Test
+    fun getIntervalFromContext() {
+        assertThat(graphIntervalProvider.getIntervalFor(null, null, null, context)).isEqualTo(
+                Interval(DateFormatUtil.FHEM_DATE_FORMAT.parseDateTime("2020-03-09 20:57:40"),
+                        DateFormatUtil.FHEM_DATE_FORMAT.parseDateTime("2020-03-10 20:57:40")))
+    }
+
+    @Test
+    fun getIntervalFromFixedRange() {
+        assertThat(graphIntervalProvider.getIntervalFor(null, null, Pair(Hours.hours(3), Hours.hours(-6)), context)).isEqualTo(
+                Interval(DateFormatUtil.FHEM_DATE_FORMAT.parseDateTime("2020-03-10 11:57:40"),
+                        DateFormatUtil.FHEM_DATE_FORMAT.parseDateTime("2020-03-10 14:57:40")))
+    }
+}

--- a/app/src/test/java/li/klass/fhem/graph/backend/GraphServiceTest.kt
+++ b/app/src/test/java/li/klass/fhem/graph/backend/GraphServiceTest.kt
@@ -90,7 +90,7 @@ class GraphServiceTest {
 
     @Before
     fun setUp() {
-        given(graphIntervalProvider.getIntervalFor(from, to, context)).willReturn(interval)
+        given(graphIntervalProvider.getIntervalFor(from, to, null, context)).willReturn(interval)
     }
 
     @Test
@@ -196,6 +196,8 @@ class GraphServiceTest {
                     ),
                     rightAxis = GPlotAxisTestdataCreator.defaultGPlotAxis().copy(series = emptyList())
             ),
+            fixedrange = null,
+            plotReplace = emptyMap(),
             plotfunction = emptyList(),
             title = "abc"
     )
@@ -212,11 +214,13 @@ class GraphServiceTest {
         @DataProvider
         fun graphEntryProvider(): List<GraphEntryParseTestCase> {
             val dateTime = DateTime(2013, 3, 21, 16, 38, 39)
+            val dateTime2 = DateTime(2013, 1, 1, 0, 0, 0)
             return listOf(
                     GraphEntryParseTestCase("2013-03-21_16:38:39 5.7\n", GraphEntry(dateTime, 5.7f)),
                     GraphEntryParseTestCase("2013-03-21_16:38:39 5.7", GraphEntry(dateTime, 5.7f)),
                     GraphEntryParseTestCase("2013-03-21_16:38:39 -5.7\n", GraphEntry(dateTime, -5.7f)),
-                    GraphEntryParseTestCase("2013-03-21_16:38 5.7\n", null),
+                    GraphEntryParseTestCase("2013 5.7\n", GraphEntry(dateTime2, 5.7f)),
+                    GraphEntryParseTestCase("2013_03_21_16:38:39 5.7\n", null),
                     GraphEntryParseTestCase("2013-03-21_16:38:39\n", null)
             )
         }


### PR DESCRIPTION
This pull request is a suggestion how to handle #1341 and #1343:

### plotReplace
- Read and parse plotReplace attribute of SVG devices
- Replace %key% by respective value in get command (replacement before input processing)

Disclaimer
- No evaluation of perl expressions in {}
- No treatment of <key> (replacement after input processing) [I'm not sure whether this is relevant for andFHEM]
- No treatment of special variables $data{min1} etc. (only relevant for <key> replacement)

### fixedrange
- Read and parse fixedrange attribute of SVG devices
- Set default startDate and endDate based on fixedrange value
- Supported fixedrange values: <range> [offset]
  where range is one of hour, <N>hours, day, <N>days, week, <N>weeks, month, <N>months, year, <N>years
  and offset is an integer.
- Calculation of startDate and endDate behaves basically as if endPlotNow was set to 1

Disclaimer:
- No support for fixed dates (in the form YYYY-MM-DD)
- endPlotNow and endPlotToday are not evaluated